### PR TITLE
fix: Throw targeted exceptions if disconnection event occurs

### DIFF
--- a/src/Darp.Ble.Hci/AclConnection.cs
+++ b/src/Darp.Ble.Hci/AclConnection.cs
@@ -69,46 +69,28 @@ public sealed class AclConnection : IDisposable
         if (txTime is < 0x0148 or > 0x4290)
             throw new ArgumentOutOfRangeException(nameof(txOctets));
         ThrowIfDisconnected("set data length");
-        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, DisconnectToken);
-        try
-        {
-            await Device
-                .Host.QueryCommandCompletionAsync<HciLeSetDataLengthCommand, HciLeSetDataLengthResult>(
-                    new HciLeSetDataLengthCommand
-                    {
-                        ConnectionHandle = ConnectionHandle,
-                        TxOctets = txOctets,
-                        TxTime = txTime,
-                    },
-                    cancellationToken: tokenSource.Token
-                )
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException exception)
-            when (!token.IsCancellationRequested && DisconnectToken.IsCancellationRequested)
-        {
-            throw CreateDisconnectedException("set data length", exception);
-        }
+        await Device
+            .Host.QueryCommandCompletionAsync<HciLeSetDataLengthCommand, HciLeSetDataLengthResult>(
+                new HciLeSetDataLengthCommand
+                {
+                    ConnectionHandle = ConnectionHandle,
+                    TxOctets = txOctets,
+                    TxTime = txTime,
+                },
+                cancellationToken: token
+            )
+            .ConfigureAwait(false);
     }
 
     public async Task<HciLeReadPhyResult> ReadPhyAsync(CancellationToken token = default)
     {
         ThrowIfDisconnected("read phy");
-        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, DisconnectToken);
-        try
-        {
-            return await Device
-                .Host.QueryCommandCompletionAsync<HciLeReadPhyCommand, HciLeReadPhyResult>(
-                    new HciLeReadPhyCommand { ConnectionHandle = ConnectionHandle },
-                    cancellationToken: tokenSource.Token
-                )
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException exception)
-            when (!token.IsCancellationRequested && DisconnectToken.IsCancellationRequested)
-        {
-            throw CreateDisconnectedException("read phy", exception);
-        }
+        return await Device
+            .Host.QueryCommandCompletionAsync<HciLeReadPhyCommand, HciLeReadPhyResult>(
+                new HciLeReadPhyCommand { ConnectionHandle = ConnectionHandle },
+                cancellationToken: token
+            )
+            .ConfigureAwait(false);
     }
 
     internal void OnDisconnectEvent(HciDisconnectionCompleteEvent hciEvent)
@@ -140,6 +122,7 @@ public sealed class AclConnection : IDisposable
             .ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         if (DisconnectToken.IsCancellationRequested)

--- a/src/Darp.Ble.Hci/AclConnection.cs
+++ b/src/Darp.Ble.Hci/AclConnection.cs
@@ -1,3 +1,4 @@
+using Darp.Ble.Hci.Exceptions;
 using Darp.Ble.Hci.Host;
 using Darp.Ble.Hci.Payload;
 using Darp.Ble.Hci.Payload.Att;
@@ -59,6 +60,7 @@ public sealed class AclConnection : IDisposable
     public L2CapAssembler Assembler { get; }
     public IAclPacketQueue AclPacketQueue => Device.Host.AclPacketQueue;
     public CancellationToken DisconnectToken => _disconnectSource.Token;
+    public HciCommandStatus? LastDisconnectionReason { get; private set; }
 
     public async Task SetDataLengthAsync(ushort txOctets, ushort txTime, CancellationToken token = default)
     {
@@ -66,27 +68,47 @@ public sealed class AclConnection : IDisposable
             throw new ArgumentOutOfRangeException(nameof(txOctets));
         if (txTime is < 0x0148 or > 0x4290)
             throw new ArgumentOutOfRangeException(nameof(txOctets));
-        await Device
-            .Host.QueryCommandCompletionAsync<HciLeSetDataLengthCommand, HciLeSetDataLengthResult>(
-                new HciLeSetDataLengthCommand
-                {
-                    ConnectionHandle = ConnectionHandle,
-                    TxOctets = txOctets,
-                    TxTime = txTime,
-                },
-                cancellationToken: token
-            )
-            .ConfigureAwait(false);
+        ThrowIfDisconnected("set data length");
+        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, DisconnectToken);
+        try
+        {
+            await Device
+                .Host.QueryCommandCompletionAsync<HciLeSetDataLengthCommand, HciLeSetDataLengthResult>(
+                    new HciLeSetDataLengthCommand
+                    {
+                        ConnectionHandle = ConnectionHandle,
+                        TxOctets = txOctets,
+                        TxTime = txTime,
+                    },
+                    cancellationToken: tokenSource.Token
+                )
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception)
+            when (!token.IsCancellationRequested && DisconnectToken.IsCancellationRequested)
+        {
+            throw CreateDisconnectedException("set data length", exception);
+        }
     }
 
     public async Task<HciLeReadPhyResult> ReadPhyAsync(CancellationToken token = default)
     {
-        return await Device
-            .Host.QueryCommandCompletionAsync<HciLeReadPhyCommand, HciLeReadPhyResult>(
-                new HciLeReadPhyCommand { ConnectionHandle = ConnectionHandle },
-                cancellationToken: token
-            )
-            .ConfigureAwait(false);
+        ThrowIfDisconnected("read phy");
+        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, DisconnectToken);
+        try
+        {
+            return await Device
+                .Host.QueryCommandCompletionAsync<HciLeReadPhyCommand, HciLeReadPhyResult>(
+                    new HciLeReadPhyCommand { ConnectionHandle = ConnectionHandle },
+                    cancellationToken: tokenSource.Token
+                )
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception)
+            when (!token.IsCancellationRequested && DisconnectToken.IsCancellationRequested)
+        {
+            throw CreateDisconnectedException("read phy", exception);
+        }
     }
 
     internal void OnDisconnectEvent(HciDisconnectionCompleteEvent hciEvent)
@@ -98,6 +120,7 @@ public sealed class AclConnection : IDisposable
             hciEvent.ConnectionHandle,
             hciEvent.Reason
         );
+        LastDisconnectionReason = hciEvent.Reason;
         _disconnectSource.Cancel();
     }
 
@@ -124,6 +147,17 @@ public sealed class AclConnection : IDisposable
         _disconnectSource.Cancel();
         _disconnectSource.Dispose();
         _subscription.Dispose();
+    }
+
+    internal HciConnectionDisconnectedException CreateDisconnectedException(
+        string operation,
+        Exception? innerException = null
+    ) => new(ConnectionHandle, operation, LastDisconnectionReason, innerException);
+
+    private void ThrowIfDisconnected(string operation)
+    {
+        if (DisconnectToken.IsCancellationRequested)
+            throw CreateDisconnectedException(operation);
     }
 }
 

--- a/src/Darp.Ble.Hci/AclConnection.cs
+++ b/src/Darp.Ble.Hci/AclConnection.cs
@@ -22,6 +22,7 @@ public sealed class AclConnection : IDisposable
 {
     private readonly CancellationTokenSource _disconnectSource = new();
     private readonly IDisposable _subscription;
+    private bool _isDisposed;
 
     public AclConnection(
         HciDevice device,
@@ -125,9 +126,12 @@ public sealed class AclConnection : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        if (DisconnectToken.IsCancellationRequested)
+        if (_isDisposed)
             return;
-        _disconnectSource.Cancel();
+
+        _isDisposed = true;
+        if (!DisconnectToken.IsCancellationRequested)
+            _disconnectSource.Cancel();
         _disconnectSource.Dispose();
         _subscription.Dispose();
     }

--- a/src/Darp.Ble.Hci/AclConnectionExtensions.cs
+++ b/src/Darp.Ble.Hci/AclConnectionExtensions.cs
@@ -26,6 +26,8 @@ public static class AclConnectionExtensions
     {
         ArgumentNullException.ThrowIfNull(connection);
         timeout ??= TimeSpan.FromMilliseconds(connection.Device.Settings.DefaultAttTimeoutMs);
+        if (connection.DisconnectToken.IsCancellationRequested)
+            throw connection.CreateDisconnectedException($"ATT query {request.OpCode}");
         using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
             connection.DisconnectToken
@@ -47,6 +49,11 @@ public static class AclConnectionExtensions
             string responseName = response.OpCode.ToString().ToUpperInvariant();
             activity?.SetTag("Response.OpCode", responseName);
             return response;
+        }
+        catch (OperationCanceledException exception)
+            when (!cancellationToken.IsCancellationRequested && connection.DisconnectToken.IsCancellationRequested)
+        {
+            throw connection.CreateDisconnectedException($"ATT query {request.OpCode}", exception);
         }
         catch (Exception e)
         {

--- a/src/Darp.Ble.Hci/Exceptions/HciConnectionDisconnectedException.cs
+++ b/src/Darp.Ble.Hci/Exceptions/HciConnectionDisconnectedException.cs
@@ -1,0 +1,42 @@
+using Darp.Ble.Hci.Payload;
+
+namespace Darp.Ble.Hci.Exceptions;
+
+/// <summary> Represents an error caused by an ACL connection being disconnected while an operation was in-flight </summary>
+public sealed class HciConnectionDisconnectedException : HciException
+{
+    /// <summary> Initialize a new <see cref="HciConnectionDisconnectedException"/> </summary>
+    /// <param name="connectionHandle"> The disconnected connection handle </param>
+    /// <param name="operation"> The operation that was interrupted </param>
+    /// <param name="disconnectReason"> The reported disconnect reason, if known </param>
+    /// <param name="innerException"> The inner exception </param>
+    public HciConnectionDisconnectedException(
+        ushort connectionHandle,
+        string operation,
+        HciCommandStatus? disconnectReason = null,
+        Exception? innerException = null
+    )
+        : base(GetMessage(connectionHandle, operation, disconnectReason), innerException)
+    {
+        ConnectionHandle = connectionHandle;
+        Operation = operation;
+        DisconnectReason = disconnectReason;
+    }
+
+    /// <summary> The disconnected connection handle </summary>
+    public ushort ConnectionHandle { get; }
+
+    /// <summary> The operation that was interrupted by the disconnect </summary>
+    public string Operation { get; }
+
+    /// <summary> The disconnect reason, if it was reported before the operation failed </summary>
+    public HciCommandStatus? DisconnectReason { get; }
+
+    private static string GetMessage(ushort connectionHandle, string operation, HciCommandStatus? disconnectReason)
+    {
+        string message = $"Connection 0x{connectionHandle:X} was disconnected while performing {operation}";
+        if (disconnectReason is { } reason)
+            message += $" ({reason})";
+        return message + ".";
+    }
+}

--- a/src/Darp.Ble.Hci/Exceptions/HciException.cs
+++ b/src/Darp.Ble.Hci/Exceptions/HciException.cs
@@ -14,6 +14,6 @@ public class HciException : Exception
     /// <summary> Initialize a new <see cref="HciException"/> with a message and exception </summary>
     /// <param name="message"> The message of the exception </param>
     /// <param name="innerException"> The inner exception </param>
-    public HciException(string message, Exception innerException)
+    public HciException(string message, Exception? innerException)
         : base(message, innerException) { }
 }

--- a/src/Darp.Ble.Hci/Host/HciHost.cs
+++ b/src/Darp.Ble.Hci/Host/HciHost.cs
@@ -266,6 +266,8 @@ public sealed partial class HciHost(HciDevice hciDevice, ITransportLayer transpo
             case HciEventCode.HCI_Disconnection_Complete
                 when HciDisconnectionCompleteEvent.TryReadLittleEndian(packet.DataBytes.Span, out var evt):
                 LogEventPacketControllerToHost(evt, packet.DataBytes);
+                if (Device.TryGetConnection(evt.ConnectionHandle, out AclConnection? connection))
+                    connection.OnDisconnectEvent(evt);
                 PublishMessage(evt);
                 Device.RemoveConnection(evt.ConnectionHandle);
                 break;

--- a/src/Darp.Ble.HciHost/HciHostBleCentral.cs
+++ b/src/Darp.Ble.HciHost/HciHostBleCentral.cs
@@ -1,7 +1,9 @@
 using System.Reactive.Linq;
 using Darp.Ble.Data;
+using Darp.Ble.Exceptions;
 using Darp.Ble.Gatt.Server;
 using Darp.Ble.Hci;
+using Darp.Ble.Hci.Exceptions;
 using Darp.Ble.HciHost.Gatt.Server;
 using Darp.Ble.Implementation;
 using Microsoft.Extensions.Logging;
@@ -45,11 +47,41 @@ internal sealed class HciHostBleCentral(HciHostBleDevice device, ILogger<HciHost
             {
                 return Observable.FromAsync<IGattServerPeer>(async token =>
                 {
-                    var hciPeer = (HciHostGattServerPeer)peer;
-                    await hciPeer.ReadPhyAsync(token).ConfigureAwait(false);
-                    await hciPeer.RequestExchangeMtuAsync(65, token).ConfigureAwait(false);
+                    await RunInitializationStepAsync((HciHostGattServerPeer)peer, token).ConfigureAwait(false);
                     return peer;
                 });
             })
             .Concat();
+
+    private async Task RunInitializationStepAsync(HciHostGattServerPeer peer, CancellationToken token)
+    {
+        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, peer.Connection.DisconnectToken);
+        try
+        {
+            await peer.ReadPhyAsync(token).ConfigureAwait(false);
+            await peer.RequestExchangeMtuAsync(65, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HciConnectionDisconnectedException exception)
+        {
+            throw new BleCentralConnectionInitializationFailedException(
+                this,
+                peer.Address,
+                peer.ConnectionHandle,
+                exception
+            );
+        }
+        catch (Exception exception)
+        {
+            throw new BleCentralConnectionInitializationFailedException(
+                this,
+                peer.Address,
+                peer.ConnectionHandle,
+                exception
+            );
+        }
+    }
 }

--- a/src/Darp.Ble/Exceptions/BleCentralConnectionFailedException.cs
+++ b/src/Darp.Ble/Exceptions/BleCentralConnectionFailedException.cs
@@ -3,11 +3,18 @@ using Darp.Ble.Implementation;
 namespace Darp.Ble.Exceptions;
 
 /// <summary> Represents error thrown when connection attempt has failed </summary>
-public sealed class BleCentralConnectionFailedException : BleCentralException
+public class BleCentralConnectionFailedException : BleCentralException
 {
     /// <summary> Initialize a new exception when a connection attempt has failed </summary>
     /// <param name="central"> The central responsible for connection </param>
     /// <param name="message"> The message </param>
     public BleCentralConnectionFailedException(BleCentral central, string? message)
         : base(central, message) { }
+
+    /// <summary> Initialize a new exception when a connection attempt has failed </summary>
+    /// <param name="central"> The central responsible for connection </param>
+    /// <param name="message"> The message </param>
+    /// <param name="innerException"> The inner exception </param>
+    public BleCentralConnectionFailedException(BleCentral central, string? message, Exception innerException)
+        : base(central, message, innerException) { }
 }

--- a/src/Darp.Ble/Exceptions/BleCentralConnectionInitializationFailedException.cs
+++ b/src/Darp.Ble/Exceptions/BleCentralConnectionInitializationFailedException.cs
@@ -1,0 +1,32 @@
+using Darp.Ble.Data;
+using Darp.Ble.Implementation;
+
+namespace Darp.Ble.Exceptions;
+
+/// <summary> Represents an error thrown when post-connect initialization failed while connecting to a peripheral </summary>
+public sealed class BleCentralConnectionInitializationFailedException : BleCentralConnectionFailedException
+{
+    /// <summary> Initialize a new exception when post-connect initialization failed </summary>
+    /// <param name="central"> The central responsible for the connection </param>
+    /// <param name="address"> The address of the peer that was being connected </param>
+    /// <param name="stage"> The initialization stage that failed </param>
+    /// <param name="connectionHandle"> The connection handle, if known </param>
+    /// <param name="innerException"> The underlying failure </param>
+    public BleCentralConnectionInitializationFailedException(
+        BleCentral central,
+        BleAddress address,
+        ushort? connectionHandle,
+        Exception innerException
+    )
+        : base(central, $"Connection to {address} failed during initialization.", innerException)
+    {
+        Address = address;
+        ConnectionHandle = connectionHandle;
+    }
+
+    /// <summary> The address of the peer that was being connected </summary>
+    public BleAddress Address { get; }
+
+    /// <summary> The connection handle, if it was known when the failure occurred </summary>
+    public ushort? ConnectionHandle { get; }
+}

--- a/src/Darp.Ble/Exceptions/BleCentralException.cs
+++ b/src/Darp.Ble/Exceptions/BleCentralException.cs
@@ -3,10 +3,27 @@ using Darp.Ble.Implementation;
 namespace Darp.Ble.Exceptions;
 
 /// <summary> Represents error thrown by a <see cref="Central"/> </summary>
-/// <param name="central"> The ble central </param>
-/// <param name="message"> The message </param>
-public class BleCentralException(BleCentral central, string? message) : Exception(message)
+public abstract class BleCentralException : Exception
 {
+    /// <summary> Initialize a new <see cref="BleCentralException"/> </summary>
+    /// <param name="central"> The ble central </param>
+    /// <param name="message"> The message </param>
+    protected BleCentralException(BleCentral central, string? message)
+        : base(message)
+    {
+        Central = central;
+    }
+
+    /// <summary> Initialize a new <see cref="BleCentralException"/> </summary>
+    /// <param name="central"> The ble central </param>
+    /// <param name="message"> The message </param>
+    /// <param name="innerException"> The inner exception </param>
+    protected BleCentralException(BleCentral central, string? message, Exception innerException)
+        : base(message, innerException)
+    {
+        Central = central;
+    }
+
     /// <summary> The BleCentral </summary>
-    public BleCentral Central { get; } = central;
+    public BleCentral Central { get; }
 }

--- a/test/Darp.Ble.HciHost.Tests/CentralTests.ConnectToPeripheral_ZeroConnectionHandle_DisconnectBeforeMtuResponse_ShouldThrowConnectionInitializationFailedException.verified.txt
+++ b/test/Darp.Ble.HciHost.Tests/CentralTests.ConnectToPeripheral_ZeroConnectionHandle_DisconnectBeforeMtuResponse_ShouldThrowConnectionInitializationFailedException.verified.txt
@@ -1,0 +1,44 @@
+{
+  MessagesToController: [
+    {
+      Type: HciCommand,
+      OpCode: HCI_LE_Extended_Create_Connection_V1,
+      PduBytes: 0143201A00010255407182B45A01600060000C0018000000480000000000
+    },
+    {
+      Type: HciCommand,
+      OpCode: HCI_LE_READ_PHY,
+      PduBytes: 013020020000
+    },
+    {
+      Type: HciAclData,
+      AttOpCode: ATT_EXCHANGE_MTU_REQ,
+      PduBytes: 020000070003000400024100
+    }
+  ],
+  MessagesToHost: [
+    {
+      Type: HciEvent,
+      EventCode: HCI_Command_Status,
+      CommandOpCode: HCI_LE_Extended_Create_Connection_V1,
+      PduBytes: 040F0400014320
+    },
+    {
+      Type: HciEvent,
+      EventCode: HCI_LE_Meta,
+      SubEventCode: HCI_LE_Enhanced_Connection_Complete_V1,
+      PduBytes: 043E1F0A000000000255407182B45A00000000000000000000000018000000480000
+    },
+    {
+      Type: HciEvent,
+      EventCode: HCI_Command_Complete,
+      CommandOpCode: HCI_LE_READ_PHY,
+      PduBytes: 040E080130200000000101
+    },
+    {
+      Type: HciEvent,
+      EventCode: HCI_Disconnection_Complete,
+      PduBytes: 0405040000003E
+    }
+  ]
+}

--- a/test/Darp.Ble.HciHost.Tests/CentralTests.cs
+++ b/test/Darp.Ble.HciHost.Tests/CentralTests.cs
@@ -1,7 +1,13 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using Darp.Ble.Data;
+using Darp.Ble.Exceptions;
+using Darp.Ble.Gatt;
 using Darp.Ble.Gatt.Server;
+using Darp.Ble.Hci.Exceptions;
+using Darp.Ble.Hci.Package;
+using Darp.Ble.Hci.Payload;
+using Darp.Ble.Hci.Payload.Att;
 using Darp.Ble.Hci.Payload.Event;
 using Darp.Ble.HciHost.Gatt.Server;
 using Darp.Ble.HciHost.Verify;
@@ -71,5 +77,106 @@ public sealed class CentralTests
         await peer.Central.Device.DisposeAsync();
 
         await Verifier.Verify(new { replay.MessagesToController, replay.MessagesToHost });
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ConnectToPeripheral_ZeroConnectionHandle_DisconnectBeforeMtuResponse_ShouldThrowConnectionInitializationFailedException()
+    {
+        const ushort connectionHandle = 0x0000;
+        var peerAddress = BleAddress.CreateRandomAddress((UInt48)0x5AB482714055);
+
+        var responses = new List<HciMessage>(ReplayTransportLayer.InitializeBleDeviceMessages)
+        {
+            HciMessages.HciLeExtendedCreateConnectionCommandStatusEvent(),
+            HciMessages.HciLeReadPhyEvent(connectionHandle, txPhy: 0x01, rxPhy: 0x01),
+        };
+
+        ReplayTransportLayer? replay = null;
+        replay = new ReplayTransportLayer(
+            (_, i) =>
+            {
+                if (i >= responses.Count)
+                    return (null, TimeSpan.Zero);
+
+                (HciMessage? Message, TimeSpan) response = ReplayTransportLayer.IterateHciMessages(responses, i);
+                if (response.Message is { Type: HciPacketType.HciAclData })
+                    replay?.Push(HciMessages.HciNumberOfCompletedPacketsEvent(connectionHandle));
+                return response;
+            },
+            ReplayTransportLayer.InitializeBleDeviceMessages.Length,
+            logger: null
+        );
+
+        await using IBleDevice device = await Helpers.GetAndInitializeBleDeviceAsync(replay, token: Token);
+
+        Task<IGattServerPeer> connectionTask = device.Central.ConnectToPeripheral(peerAddress).FirstAsync().ToTask();
+
+        await Task.Delay(10, Token);
+        replay.Push(
+            HciMessages.HciLeEnhancedConnectionCompleteEvent(
+                connectionHandle,
+                HciLeConnectionRole.Central,
+                (byte)peerAddress.Type,
+                peerAddress.Value,
+                connectionInterval: 0x0018,
+                peripheralLatency: 0x0000,
+                supervisionTimeout: 0x0048,
+                centralClockAccuracy: 0x00
+            )
+        );
+
+        await WaitForOutgoingMessagesAsync(replay, expectedCount: 3, Token);
+
+        replay.Push(
+            HciMessages.HciDisconnectionCompleteEvent(
+                connectionHandle,
+                reason: HciCommandStatus.ConnectionFailedToBeEstablishedOrSynchronizationTimeout
+            )
+        );
+
+        await WaitForOutgoingMessagesAsync(replay, expectedCount: 3, Token);
+        var exception = await Should.ThrowAsync<BleCentralConnectionInitializationFailedException>(async () =>
+            await connectionTask
+        );
+        exception.Address.ShouldBe(peerAddress);
+        exception.ConnectionHandle.ShouldBe(connectionHandle);
+
+        var innerException = exception.InnerException.ShouldBeOfType<HciConnectionDisconnectedException>();
+        innerException.ConnectionHandle.ShouldBe(connectionHandle);
+        innerException.Operation.ShouldBe("ATT query ATT_EXCHANGE_MTU_REQ");
+        innerException.DisconnectReason.ShouldBe(
+            HciCommandStatus.ConnectionFailedToBeEstablishedOrSynchronizationTimeout
+        );
+
+        HciMessage[] messagesToController = replay.MessagesToController.ToArray();
+        string expectedCreateConnectionPayload =
+            $"43201A0001{(byte)peerAddress.Type:X2}55407182B45A01600060000C0018000000480000000000";
+
+        messagesToController.Length.ShouldBeGreaterThanOrEqualTo(3);
+        Convert.ToHexString(messagesToController[0].PduBytes).ShouldBe(expectedCreateConnectionPayload);
+        Convert.ToHexString(messagesToController[1].PduBytes).ShouldBe("3020020000");
+
+        HciAclPacket
+            .TryReadLittleEndian(messagesToController[2].PduBytes, out HciAclPacket mtuRequestPacket)
+            .ShouldBeTrue();
+        mtuRequestPacket.ConnectionHandle.ShouldBe(connectionHandle);
+        mtuRequestPacket.DataBytes.Span[4].ShouldBe((byte)AttOpCode.ATT_EXCHANGE_MTU_REQ);
+
+        await Verifier.Verify(new { replay.MessagesToController, replay.MessagesToHost });
+    }
+
+    private static async Task WaitForOutgoingMessagesAsync(
+        ReplayTransportLayer replay,
+        int expectedCount,
+        CancellationToken token
+    )
+    {
+        while (!token.IsCancellationRequested)
+        {
+            if (replay.MessagesToController.Count >= expectedCount)
+                return;
+
+            await Task.Delay(10, token);
+        }
     }
 }

--- a/test/Darp.Ble.HciHost.Tests/CentralTests.cs
+++ b/test/Darp.Ble.HciHost.Tests/CentralTests.cs
@@ -1,9 +1,11 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Reflection;
 using Darp.Ble.Data;
 using Darp.Ble.Exceptions;
 using Darp.Ble.Gatt;
 using Darp.Ble.Gatt.Server;
+using Darp.Ble.Hci;
 using Darp.Ble.Hci.Exceptions;
 using Darp.Ble.Hci.Package;
 using Darp.Ble.Hci.Payload;
@@ -165,6 +167,57 @@ public sealed class CentralTests
         await Verifier.Verify(new { replay.MessagesToController, replay.MessagesToHost });
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task ConnectToPeripheral_DisconnectComplete_ShouldDisposeConnectionResources()
+    {
+        const ushort connectionHandle = 0x0001;
+        var peerAddress = BleAddress.CreateRandomAddress((UInt48)0x112233445566);
+
+        var responses = new List<HciMessage>(ReplayTransportLayer.InitializeBleDeviceMessages)
+        {
+            HciMessages.HciLeExtendedCreateConnectionCommandStatusEvent(),
+            HciMessages.HciLeReadPhyEvent(connectionHandle, txPhy: 0x01, rxPhy: 0x01),
+            HciMessages.AttExchangeMtuResponse(connectionHandle, serverRxMtu: 65),
+        };
+
+        ReplayTransportLayer replay = new(
+            (_, i) => ReplayTransportLayer.IterateHciMessages(responses, i),
+            ReplayTransportLayer.InitializeBleDeviceMessages.Length,
+            logger: null
+        );
+
+        await using IBleDevice device = await Helpers.GetAndInitializeBleDeviceAsync(replay, token: Token);
+
+        Task<IGattServerPeer> peerTask = device.Central.ConnectToPeripheral(peerAddress).FirstAsync().ToTask(Token);
+
+        await Task.Delay(10, Token);
+        replay.Push(
+            HciMessages.HciLeEnhancedConnectionCompleteEvent(
+                connectionHandle,
+                HciLeConnectionRole.Central,
+                (byte)peerAddress.Type,
+                peerAddress.Value,
+                connectionInterval: 0x0028,
+                peripheralLatency: 0x0000,
+                supervisionTimeout: 0x01F4,
+                centralClockAccuracy: 0x01
+            )
+        );
+
+        var peer = (HciHostGattServerPeer)await peerTask;
+        CancellationTokenSource disconnectSource = GetDisconnectSource(peer.Connection);
+
+        Task<ConnectionStatus> disconnectedTask = peer
+            .WhenConnectionStatusChanged.Where(x => x is ConnectionStatus.Disconnected)
+            .FirstAsync()
+            .ToTask(Token);
+
+        replay.Push(HciMessages.HciDisconnectionCompleteEvent(connectionHandle));
+
+        (await disconnectedTask).ShouldBe(ConnectionStatus.Disconnected);
+        Should.Throw<ObjectDisposedException>(disconnectSource.Cancel);
+    }
+
     private static async Task WaitForOutgoingMessagesAsync(
         ReplayTransportLayer replay,
         int expectedCount,
@@ -178,5 +231,14 @@ public sealed class CentralTests
 
             await Task.Delay(10, token);
         }
+    }
+
+    private static CancellationTokenSource GetDisconnectSource(AclConnection connection)
+    {
+        FieldInfo field = typeof(AclConnection).GetField(
+            "_disconnectSource",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        )!;
+        return (CancellationTokenSource)field.GetValue(connection)!;
     }
 }


### PR DESCRIPTION
## Summary
If the client disconnects while the connection is in progress (or any HCI command is sent), we throw a TaskCancellationException. This is not a very transparent error. Therefore, this PR catches such exceptions and propagates them as typed exceptions.
The disconnection is often caused by DisconnectionReason 0x3E (ConnectionFailedToBeEstablishedOrSynchronizationTimeout)

## Changes
- Saving the last DisconnectReason
- Catching the TaskCancellationExceptions and rethrowing
- Throwing specific Initialization execptions during connection

## Testing
- Added regression tests

## Checklist
<!-- Additional checks
    - No dead code or debug leftovers
    - Features are properly tested
-->

- [x] PR is scoped and not oversized
- [x] Documentation (and changelog) is updated if needed
- [x] CI Pipeline is successful
- [x] Self-review was done
