### PR TITLE
fix: Properly propagate transport errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,8 @@ dotnet_diagnostic.CS9124.severity = error
 dotnet_diagnostic.CA1819.severity = none
 dotnet_diagnostic.CA1716.severity = none
 dotnet_diagnostic.CA1043.severity = none
+# Do not warn catching general exception types. With c#, you never know which exceptions occur
+dotnet_diagnostic.CA1031.severity = none
 
 # ReSharper properties
 resharper_formatter_off_tag = @formatter:off

--- a/src/Darp.Ble.Android/AndroidBleObserver.cs
+++ b/src/Darp.Ble.Android/AndroidBleObserver.cs
@@ -41,8 +41,11 @@ public sealed class AndroidBleObserver(
             failure =>
             {
                 if (_scanCallback is not null)
+                {
                     _bluetoothLeScanner.StopScan(_scanCallback);
-                _scanCallback = null;
+                    _scanCallback.Dispose();
+                    _scanCallback = null;
+                }
                 _ = OnErrorAsync(
                     new BleObservationException(this, $"Scan failed because of {failure}", innerException: null)
                 );

--- a/src/Darp.Ble.Android/AndroidBleObserver.cs
+++ b/src/Darp.Ble.Android/AndroidBleObserver.cs
@@ -40,8 +40,12 @@ public sealed class AndroidBleObserver(
             },
             failure =>
             {
-                Logger.LogError("Scan failure because of {Failure}", failure);
-                _ = StopObservingAsync();
+                if (_scanCallback is not null)
+                    _bluetoothLeScanner.StopScan(_scanCallback);
+                _scanCallback = null;
+                _ = OnErrorAsync(
+                    new BleObservationException(this, $"Scan failed because of {failure}", innerException: null)
+                );
             }
         );
         using var settingsBuilder = new ScanSettings.Builder();

--- a/src/Darp.Ble.Hci/Host/HciHost.cs
+++ b/src/Darp.Ble.Hci/Host/HciHost.cs
@@ -15,6 +15,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Darp.Ble.Hci.Host;
 
+/// <summary> Provides the fatal exception raised by the transport layer. </summary>
+public sealed class HciTransportFailedEventArgs(Exception exception) : EventArgs
+{
+    /// <summary> The fatal transport exception. </summary>
+    public Exception Exception { get; } = exception;
+}
+
 /// <summary>
 /// The <see cref="HciHost"/> is responsible for all host-related commands.
 /// </summary>
@@ -28,6 +35,9 @@ public sealed partial class HciHost(HciDevice hciDevice, ITransportLayer transpo
     private readonly SemaphoreSlim _packetInFlightSemaphore = new(1);
     private AclPacketQueue? _leAclPacketQueue;
     private bool _isResetDoneAtLeastOnce;
+
+    /// <summary> An event that notifies when the transport has failed </summary>
+    public event EventHandler<HciTransportFailedEventArgs>? TransportFailed;
 
     /// <summary> The HCI Device </summary>
     public HciDevice Device { get; } = hciDevice;
@@ -44,7 +54,7 @@ public sealed partial class HciHost(HciDevice hciDevice, ITransportLayer transpo
     public async Task ResetAsync(CancellationToken token)
     {
         ObjectDisposedException.ThrowIf(Device.IsDisposed, this);
-        await _transportLayer.InitializeAsync(OnReceivedPacket, token).ConfigureAwait(false);
+        await _transportLayer.InitializeAsync(OnReceivedPacket, OnTransportFailed, token).ConfigureAwait(false);
         Activity? activity = Logging.StartInitializeHciHostActivity();
         try
         {
@@ -232,6 +242,11 @@ public sealed partial class HciHost(HciDevice hciDevice, ITransportLayer transpo
                 }
                 break;
         }
+    }
+
+    private void OnTransportFailed(Exception exception)
+    {
+        TransportFailed?.Invoke(this, new HciTransportFailedEventArgs(exception));
     }
 
     private void OnReceivedHciEventPacket(HciPacketEvent packet)

--- a/src/Darp.Ble.Hci/Transport/H4TransportLayer.cs
+++ b/src/Darp.Ble.Hci/Transport/H4TransportLayer.cs
@@ -26,21 +26,55 @@ public sealed class H4TransportLayer(string portName, ILogger<H4TransportLayer>?
     private readonly SerialPort _serialPort = new(portName);
     private readonly Channel<IHciPacket> _txQueue = Channel.CreateUnbounded<IHciPacket>();
     private readonly CancellationTokenSource _cancelSource = new();
+    private Action<Exception>? _onError;
     private bool _isDisposing;
+    private int _isFaulted;
     private Task? _rxTask;
     private Task? _txTask;
 
     private CancellationToken StopToken => _cancelSource.Token;
 
     /// <inheritdoc />
-    public ValueTask InitializeAsync(Action<HciPacket> onReceived, CancellationToken cancellationToken)
+    public ValueTask InitializeAsync(
+        Action<HciPacket> onReceived,
+        Action<Exception> onError,
+        CancellationToken cancellationToken
+    )
     {
         if (_txTask is not null || _rxTask is not null)
             throw new InvalidOperationException("Initialization can only be done once");
+        _onError = onError;
         _serialPort.Open();
         _txTask = Task.Run(RunTx, cancellationToken);
         _rxTask = Task.Run(() => RunRx(onReceived), cancellationToken);
         return ValueTask.CompletedTask;
+    }
+
+    private void ReportTransportFailure(Exception exception, string direction)
+    {
+        if (Interlocked.Exchange(ref _isFaulted, 1) != 0)
+            return;
+
+        _logger?.LogH4TransportWithError(exception, direction, exception.Message);
+        try
+        {
+            _cancelSource.Cancel();
+        }
+        catch
+        {
+            // Ignore cancellation errors while reporting a fatal transport failure
+        }
+
+        try
+        {
+            _serialPort.Close();
+        }
+        catch
+        {
+            // Ignore close errors while reporting a fatal transport failure
+        }
+
+        _onError?.Invoke(exception);
     }
 
     private async Task RunTx()
@@ -77,7 +111,7 @@ public sealed class H4TransportLayer(string portName, ILogger<H4TransportLayer>?
                 _logger?.LogH4TransportDisconnected("Tx");
                 return;
             }
-            _logger?.LogH4TransportWithError(e, "Tx", e.Message);
+            ReportTransportFailure(e, "Tx");
         }
 #pragma warning restore CA1031
     }
@@ -130,7 +164,7 @@ public sealed class H4TransportLayer(string portName, ILogger<H4TransportLayer>?
                 return;
             }
 
-            _logger?.LogH4TransportWithError(e, "Rx", e.Message);
+            ReportTransportFailure(e, "Rx");
         }
 #pragma warning restore CA1031
     }

--- a/src/Darp.Ble.Hci/Transport/ITransportLayer.cs
+++ b/src/Darp.Ble.Hci/Transport/ITransportLayer.cs
@@ -10,5 +10,9 @@ public interface ITransportLayer : IAsyncDisposable
     void Enqueue(IHciPacket packet);
 
     /// <summary> Initialize the transport layer </summary>
-    ValueTask InitializeAsync(Action<HciPacket> onReceived, CancellationToken cancellationToken);
+    ValueTask InitializeAsync(
+        Action<HciPacket> onReceived,
+        Action<Exception> onError,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/Darp.Ble.HciHost/HciHostBleObserver.cs
+++ b/src/Darp.Ble.HciHost/HciHostBleObserver.cs
@@ -27,6 +27,14 @@ internal sealed partial class HciHostBleObserver : BleObserver
     {
         _device = device;
         _subscription = Host.Subscribe(this);
+        Host.TransportFailed += OnTransportFailed;
+    }
+
+    private void OnTransportFailed(object? sender, HciTransportFailedEventArgs args)
+    {
+        _ = OnErrorAsync(
+            new BleObservationException(this, "The HCI transport failed while observing advertisements", args.Exception)
+        );
     }
 
     [MessageSink]
@@ -121,6 +129,7 @@ internal sealed partial class HciHostBleObserver : BleObserver
 
     protected override ValueTask DisposeAsyncCore()
     {
+        Host.TransportFailed -= OnTransportFailed;
         _subscription.Dispose();
         return base.DisposeAsyncCore();
     }

--- a/src/Darp.Ble.WinRT/WinBleObserver.cs
+++ b/src/Darp.Ble.WinRT/WinBleObserver.cs
@@ -53,8 +53,12 @@ internal sealed class WinBleObserver(BleDevice device, ILogger<WinBleObserver> l
         {
             if (args.Error is BluetoothError.Success)
                 return;
-            Logger.LogError("Watcher stopped with error {Error}", args.Error);
-            await StopObservingAsync().ConfigureAwait(false);
+            _observableSubscription?.Dispose();
+            _watcher = null;
+            await OnErrorAsync(
+                    new BleObservationException(this, $"Watcher stopped with error {args.Error}", innerException: null)
+                )
+                .ConfigureAwait(false);
         };
         _observableSubscription = Observable
             .FromEventPattern<
@@ -63,7 +67,7 @@ internal sealed class WinBleObserver(BleDevice device, ILogger<WinBleObserver> l
                 BluetoothLEAdvertisementReceivedEventArgs
             >(addHandler => _watcher.Received += addHandler, removeHandler => _watcher.Received -= removeHandler)
             .Select(adv => OnAdvertisementReport(this, adv))
-            .Subscribe(OnNext);
+            .Subscribe(adv => OnNext(adv));
         return Task.CompletedTask;
     }
 

--- a/src/Darp.Ble/BleObserverExtensions.cs
+++ b/src/Darp.Ble/BleObserverExtensions.cs
@@ -10,7 +10,7 @@ public static class BleObserverExtensions
 {
     /// <summary>
     /// Observes advertisements broadcast by BLE devices using the provided <see cref="IBleObserver"/>.
-    /// Will error when a fatal error has occured
+    /// Will error when a fatal error has occurred
     /// </summary>
     /// <param name="observer">The instance of <see cref="IBleObserver"/> that will monitor BLE advertisements.</param>
     /// <returns>An observable sequence of <see cref="IGapAdvertisement"/> instances representing BLE advertisements.</returns>

--- a/src/Darp.Ble/BleObserverExtensions.cs
+++ b/src/Darp.Ble/BleObserverExtensions.cs
@@ -10,13 +10,16 @@ public static class BleObserverExtensions
 {
     /// <summary>
     /// Observes advertisements broadcast by BLE devices using the provided <see cref="IBleObserver"/>.
+    /// Will error when a fatal error has occured
     /// </summary>
     /// <param name="observer">The instance of <see cref="IBleObserver"/> that will monitor BLE advertisements.</param>
     /// <returns>An observable sequence of <see cref="IGapAdvertisement"/> instances representing BLE advertisements.</returns>
     public static IObservable<IGapAdvertisement> OnAdvertisement(this IBleObserver observer)
     {
         ArgumentNullException.ThrowIfNull(observer);
-        return Observable.Create<IGapAdvertisement>(advObserver => observer.OnAdvertisement(advObserver.OnNext));
+        return Observable.Create<IGapAdvertisement>(advObserver =>
+            observer.OnAdvertisement(advObserver.OnNext, advObserver.OnError)
+        );
     }
 
     /// <summary> Publish the observer to allow observing advertisements without having to start/stop observation manually </summary>
@@ -28,7 +31,10 @@ public static class BleObserverExtensions
 
         IObservable<IGapAdvertisement> inner = Observable.Create<IGapAdvertisement>(async observer =>
         {
-            IDisposable unhook = bleObserver.OnAdvertisement(onAdvertisement: observer.OnNext);
+            IDisposable unhook = bleObserver.OnAdvertisement(
+                onAdvertisement: observer.OnNext,
+                onError: observer.OnError
+            );
 
             await bleObserver.StartObservingAsync().ConfigureAwait(false);
 

--- a/src/Darp.Ble/IBleObserver.cs
+++ b/src/Darp.Ble/IBleObserver.cs
@@ -26,8 +26,9 @@ public interface IBleObserver
 
     /// <summary> Register a callback called when an advertisement was received </summary>
     /// <param name="onAdvertisement"> The callback </param>
+    /// <param name="onError"> The callback for fatal observation errors </param>
     /// <returns> A disposable to unsubscribe the callback </returns>
-    IDisposable OnAdvertisement(Action<IGapAdvertisement> onAdvertisement);
+    IDisposable OnAdvertisement(Action<IGapAdvertisement> onAdvertisement, Action<Exception>? onError = null);
 
     /// <summary> Start observing for advertisements. </summary>
     /// <param name="cancellationToken"> The CancellationToken to cancel the initial starting process </param>

--- a/src/Darp.Ble/Implementation/BleObserver.cs
+++ b/src/Darp.Ble/Implementation/BleObserver.cs
@@ -24,10 +24,15 @@ internal enum ObserverState
 /// <param name="logger"> The logger </param>
 public abstract class BleObserver(BleDevice device, ILogger<BleObserver> logger) : IBleObserver, IAsyncDisposable
 {
+    private readonly record struct AdvertisementHandlerSubscription(
+        Action<IGapAdvertisement> OnAdvertisement,
+        Action<Exception>? OnError
+    );
+
     private readonly BleDevice _bleDevice = device;
     private readonly SemaphoreSlim _startStopSemaphore = new(1, 1);
     private readonly Lock _handlersLock = new();
-    private Action<IGapAdvertisement>[] _handlers = [];
+    private AdvertisementHandlerSubscription[] _handlers = [];
 
     private volatile ObserverState _observerState = ObserverState.Stopped;
 
@@ -103,25 +108,27 @@ public abstract class BleObserver(BleDevice device, ILogger<BleObserver> logger)
     }
 
     /// <inheritdoc />
-    public IDisposable OnAdvertisement(Action<IGapAdvertisement> onAdvertisement)
+    public IDisposable OnAdvertisement(Action<IGapAdvertisement> onAdvertisement, Action<Exception>? onError = null)
     {
         ObjectDisposedException.ThrowIf(_bleDevice.IsDisposing, nameof(BleObserver));
+
+        var subscription = new AdvertisementHandlerSubscription(onAdvertisement, onError);
 
         // Extend handlers list
         lock (_handlersLock)
         {
-            Action<IGapAdvertisement>[] oldHandlers = _handlers;
-            var newArr = new Action<IGapAdvertisement>[oldHandlers.Length + 1];
+            AdvertisementHandlerSubscription[] oldHandlers = _handlers;
+            var newArr = new AdvertisementHandlerSubscription[oldHandlers.Length + 1];
             Array.Copy(oldHandlers, newArr, oldHandlers.Length);
-            newArr[^1] = onAdvertisement;
+            newArr[^1] = subscription;
             Volatile.Write(ref _handlers, newArr);
         }
 
         return Disposable.Create(
-            (this, onAdvertisement),
+            (this, subscription),
             static tuple =>
             {
-                (BleObserver self, Action<IGapAdvertisement> handler) = tuple;
+                (BleObserver self, AdvertisementHandlerSubscription handler) = tuple;
                 lock (self._handlersLock)
                 {
                     if (Helpers.TryRemoveImmutable(self._handlers, handler, out var newHandlers))
@@ -143,17 +150,63 @@ public abstract class BleObserver(BleDevice device, ILogger<BleObserver> logger)
         // Taking the current snapshot of the handlers.
         // In case of an unsubscription of a handler we might have taken the reference here already and call it afterward.
         // This is a known tradeoff
-        Action<IGapAdvertisement>[] handlers = Volatile.Read(ref _handlers);
-        foreach (Action<IGapAdvertisement> handler in handlers)
+        AdvertisementHandlerSubscription[] handlers = Volatile.Read(ref _handlers);
+        foreach (AdvertisementHandlerSubscription handler in handlers)
         {
             try
             {
-                handler(advertisement);
+                handler.OnAdvertisement(advertisement);
             }
             catch (Exception e)
             {
                 // An exception inside the handler should not crash all observers. Logging and ignoring ...
                 Logger.LogObservationErrorDuringAdvertisementHandling(e);
+            }
+        }
+    }
+
+    /// <summary> Notify subscribers of a fatal observation error. Existing subscriptions are terminated. </summary>
+    /// <param name="exception"> The exception that triggered the error </param>
+    protected async Task OnErrorAsync(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (_bleDevice.IsDisposing)
+            return;
+
+        AdvertisementHandlerSubscription[] handlers;
+        await _startStopSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            handlers = Volatile.Read(ref _handlers);
+            if (handlers.Length == 0 && _observerState is ObserverState.Stopped)
+                return;
+
+            _observerState = ObserverState.Stopped;
+            lock (_handlersLock)
+            {
+                _handlers = [];
+            }
+        }
+        finally
+        {
+            _startStopSemaphore.Release();
+        }
+
+        Logger.LogObservationFailed(exception);
+
+        foreach (AdvertisementHandlerSubscription handler in handlers)
+        {
+            if (handler.OnError is null)
+                continue;
+
+            try
+            {
+                handler.OnError(exception);
+            }
+            catch (Exception e)
+            {
+                Logger.LogObservationErrorDuringErrorHandling(e);
             }
         }
     }

--- a/src/Darp.Ble/Logging.cs
+++ b/src/Darp.Ble/Logging.cs
@@ -26,6 +26,12 @@ internal static partial class Logging
     [LoggerMessage(Level = LogLevel.Error, Message = "Exception while handling advertisement event")]
     public static partial void LogObservationErrorDuringAdvertisementHandling(this ILogger logger, Exception e);
 
+    [LoggerMessage(Level = LogLevel.Error, Message = "Advertising observation failed")]
+    public static partial void LogObservationFailed(this ILogger logger, Exception e);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Exception while handling advertisement error")]
+    public static partial void LogObservationErrorDuringErrorHandling(this ILogger logger, Exception e);
+
     [LoggerMessage(Level = LogLevel.Error, Message = "Exception while stopping observation")]
     public static partial void LogObserverErrorDuringStopping(this ILogger logger, Exception e);
 }

--- a/test/Darp.Ble.HciHost.Tests/ObserverTests.Regression.cs
+++ b/test/Darp.Ble.HciHost.Tests/ObserverTests.Regression.cs
@@ -1,5 +1,9 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using Darp.Ble.Data;
+using Darp.Ble.Exceptions;
+using Darp.Ble.Gap;
 using Darp.Ble.HciHost.Verify;
 using Shouldly;
 
@@ -78,6 +82,27 @@ public sealed partial class ObserverTests
         {
             semaphore.Release();
         }
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task TransportFailureWhileObserving_FaultsAdvertisementObservable()
+    {
+        var transport = ReplayTransportLayer.ReplayAfterBleDeviceInitialization(ObservingMessages);
+        IBleDevice device = await Helpers.GetAndInitializeBleDeviceAsync(transport, token: Token);
+        IBleObserver observer = device.Observer;
+        Task<IGapAdvertisement> observationTask = observer.OnAdvertisement().FirstAsync().ToTask(Token);
+
+        await observer.StartObservingAsync(Token);
+        observer.IsObserving.ShouldBeTrue();
+
+        transport.Fail(new InvalidOperationException("Serial connection lost"));
+
+        var exception = await Should.ThrowAsync<BleObservationException>(() => observationTask);
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        observer.IsObserving.ShouldBeFalse();
+
+        await observer.StopObservingAsync();
+        await device.DisposeAsync();
     }
 
     private static T GetPrivateField<T>(object obj, string fieldName)

--- a/test/Darp.Ble.HciHost.Verify/ReplayTransportLayer.cs
+++ b/test/Darp.Ble.HciHost.Verify/ReplayTransportLayer.cs
@@ -38,6 +38,7 @@ public sealed class ReplayTransportLayer(
     private readonly ConcurrentQueue<HciMessage> _messagesToController = [];
     private readonly ConcurrentQueue<HciMessage> _messagesToHost = [];
     private Action<HciPacket>? _onReceived;
+    private Action<Exception>? _onError;
 
     public static readonly HciMessage[] InitializeHciDeviceMessages =
     [
@@ -114,6 +115,11 @@ public sealed class ReplayTransportLayer(
         _onReceived?.Invoke(new HciPacket(message.Type, message.PduBytes));
     }
 
+    public void Fail(Exception exception)
+    {
+        _onError?.Invoke(exception);
+    }
+
     void ITransportLayer.Enqueue(IHciPacket packet)
     {
         byte[] bytes = packet.ToArrayLittleEndian();
@@ -139,9 +145,14 @@ public sealed class ReplayTransportLayer(
         });
     }
 
-    ValueTask ITransportLayer.InitializeAsync(Action<HciPacket> onReceived, CancellationToken cancellationToken)
+    ValueTask ITransportLayer.InitializeAsync(
+        Action<HciPacket> onReceived,
+        Action<Exception> onError,
+        CancellationToken cancellationToken
+    )
     {
         _onReceived = onReceived;
+        _onError = onError;
         _logger?.LogDebug("ReplayTransportLayer: Initialized");
         return ValueTask.CompletedTask;
     }

--- a/test/Darp.Ble.HciHost.Verify/ReplayTransportLayer.cs
+++ b/test/Darp.Ble.HciHost.Verify/ReplayTransportLayer.cs
@@ -39,6 +39,7 @@ public sealed class ReplayTransportLayer(
     private readonly ConcurrentQueue<HciMessage> _messagesToHost = [];
     private Action<HciPacket>? _onReceived;
     private Action<Exception>? _onError;
+    private int _isFaulted;
 
     public static readonly HciMessage[] InitializeHciDeviceMessages =
     [
@@ -110,6 +111,12 @@ public sealed class ReplayTransportLayer(
 
     public void Push(HciMessage message)
     {
+        if (Volatile.Read(ref _isFaulted) != 0)
+        {
+            throw new InvalidOperationException(
+                "ReplayTransportLayer is faulted. There should not be any additional messages"
+            );
+        }
         _logger?.LogDebug("ReplayTransportLayer: Packet to Host: {PacketBytes}", Convert.ToHexString(message.PduBytes));
         _messagesToHost.Enqueue(message);
         _onReceived?.Invoke(new HciPacket(message.Type, message.PduBytes));
@@ -117,11 +124,23 @@ public sealed class ReplayTransportLayer(
 
     public void Fail(Exception exception)
     {
+        if (Interlocked.Exchange(ref _isFaulted, 1) != 0)
+        {
+            throw new InvalidOperationException(
+                "ReplayTransportLayer is faulted. There should not be any additional fails"
+            );
+        }
         _onError?.Invoke(exception);
     }
 
     void ITransportLayer.Enqueue(IHciPacket packet)
     {
+        if (Volatile.Read(ref _isFaulted) != 0)
+        {
+            throw new InvalidOperationException(
+                "ReplayTransportLayer is faulted. There should not be any additional messages"
+            );
+        }
         byte[] bytes = packet.ToArrayLittleEndian();
         var message = new HciMessage(HciDirection.HostToController, packet.PacketType, bytes);
         _messagesToController.Enqueue(message);
@@ -134,6 +153,8 @@ public sealed class ReplayTransportLayer(
 
         _ = Task.Run(async () =>
         {
+            if (Volatile.Read(ref _isFaulted) != 0)
+                return;
             await Task.Delay(response.Value.Delay);
 
             _logger?.LogDebug(

--- a/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
+++ b/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
@@ -18,6 +18,15 @@ namespace Darp.Ble.Tests.Implementation;
 
 public sealed class BleObserverTests(ILoggerFactory loggerFactory)
 {
+    private sealed class TestBleObserver(BleDevice device, ILogger<BleObserver> logger) : BleObserver(device, logger)
+    {
+        protected override Task StartObservingAsyncCore(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override Task StopObservingAsyncCore() => Task.CompletedTask;
+
+        public Task FailAsync(Exception exception) => OnErrorAsync(exception);
+    }
+
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private const string AdDataFlagsLimitedDiscoverableShortenedLocalNameTestName = "0201010908546573744E616D65";
 
@@ -169,5 +178,39 @@ public sealed class BleObserverTests(ILoggerFactory loggerFactory)
         await device.DisposeAsync();
         Action xx = () => device.Observer.OnAdvertisement(_ => { });
         xx.ShouldThrow<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task OnAdvertisement_WhenObservationFails_ShouldInvokeErrorAndTerminateSubscription()
+    {
+        var device = Substitute.For<BleDevice>(null!, null!);
+        var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
+        var exception = new BleObservationException(observer, "transport failed", innerException: null);
+        var receivedErrors = new List<Exception>();
+        var receivedAdvertisements = 0;
+
+        observer.OnAdvertisement(_ => receivedAdvertisements++, receivedErrors.Add);
+
+        await observer.FailAsync(exception);
+        await observer.StartObservingAsync(Token);
+        await observer.FailAsync(exception);
+
+        receivedAdvertisements.ShouldBe(0);
+        receivedErrors.ShouldHaveSingleItem();
+        receivedErrors[0].ShouldBe(exception);
+    }
+
+    [Fact]
+    public async Task OnAdvertisementObservable_WhenObservationFails_ShouldFault()
+    {
+        var device = Substitute.For<BleDevice>(null!, null!);
+        var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
+        var exception = new BleObservationException(observer, "transport failed", innerException: null);
+        Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
+
+        await observer.FailAsync(exception);
+
+        var actualException = await Should.ThrowAsync<BleObservationException>(() => task);
+        actualException.ShouldBe(exception);
     }
 }

--- a/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
+++ b/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
@@ -191,7 +191,6 @@ public sealed class BleObserverTests(ILoggerFactory loggerFactory)
 
         observer.OnAdvertisement(_ => receivedAdvertisements++, receivedErrors.Add);
 
-        await observer.FailAsync(exception);
         await observer.StartObservingAsync(Token);
         await observer.FailAsync(exception);
 
@@ -207,6 +206,22 @@ public sealed class BleObserverTests(ILoggerFactory loggerFactory)
         var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
         var exception = new BleObservationException(observer, "transport failed", innerException: null);
         Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
+        await observer.StartObservingAsync(Token);
+
+        await observer.FailAsync(exception);
+
+        var actualException = await Should.ThrowAsync<BleObservationException>(() => task);
+        actualException.ShouldBe(exception);
+    }
+
+    [Fact]
+    public async Task OnAdvertisementObservable_WhenStoppedAndObservationFails_ShouldFault()
+    {
+        var device = Substitute.For<BleDevice>(null!, null!);
+        var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
+        var exception = new BleObservationException(observer, "transport failed", innerException: null);
+        Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
+        await observer.StartObservingAsync(Token);
 
         await observer.FailAsync(exception);
 

--- a/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
+++ b/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
@@ -221,7 +221,20 @@ public sealed class BleObserverTests(ILoggerFactory loggerFactory)
         var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
         var exception = new BleObservationException(observer, "transport failed", innerException: null);
         Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
-        await observer.StartObservingAsync(Token);
+
+        await observer.FailAsync(exception);
+
+        var actualException = await Should.ThrowAsync<BleObservationException>(() => task);
+        actualException.ShouldBe(exception);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task PublishObservable_WhenObservationFails_ShouldFault()
+    {
+        var device = Substitute.For<BleDevice>(null!, null!);
+        var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
+        var exception = new BleObservationException(observer, "transport failed", innerException: null);
+        Task<IGapAdvertisement> task = observer.Publish().RefCount().FirstAsync().ToTask();
 
         await observer.FailAsync(exception);
 

--- a/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
+++ b/test/Darp.Ble.Tests/Implementation/BleObserverTests.cs
@@ -215,12 +215,28 @@ public sealed class BleObserverTests(ILoggerFactory loggerFactory)
     }
 
     [Fact]
+    public async Task OnAdvertisementObservable_WhenNotStartedAndObservationFails_ShouldFault()
+    {
+        var device = Substitute.For<BleDevice>(null!, null!);
+        var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
+        var exception = new BleObservationException(observer, "transport failed", innerException: null);
+        Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
+
+        await observer.FailAsync(exception);
+
+        var actualException = await Should.ThrowAsync<BleObservationException>(() => task);
+        actualException.ShouldBe(exception);
+    }
+
+    [Fact]
     public async Task OnAdvertisementObservable_WhenStoppedAndObservationFails_ShouldFault()
     {
         var device = Substitute.For<BleDevice>(null!, null!);
         var observer = new TestBleObserver(device, _loggerFactory.CreateLogger<BleObserver>());
         var exception = new BleObservationException(observer, "transport failed", innerException: null);
         Task<IGapAdvertisement> task = observer.OnAdvertisement().FirstAsync().ToTask();
+        await observer.StartObservingAsync(Token);
+        await observer.StopObservingAsync();
 
         await observer.FailAsync(exception);
 


### PR DESCRIPTION
## Summary
Right now, if a transport (e.g., the H4Transport) fails, we only log the error but never propagate it to the user, meaning, e.g., an OnAdvertisement call might hang forever, and the user has no way of knowing. This PR introduces error propagation to the BleObserver.

## Changes
- Added an onError for HciTransports
- Added onError to the OnAdvertisement of IBleObserver
- Raising errors in HciTransports, Windows Observers, and Android observers

## Testing
- Added unit tests

## Impact
- Breaking the onAdvertisement function
- OnAdvertisement (IObservable) might now return errors

## Checklist
<!-- Additional checks
    - No dead code or debug leftovers
    - Features are properly tested
-->

- [x] PR is scoped and not oversized
- [x] Documentation (and changelog) is updated if needed
- [x] CI Pipeline is successful
- [x] Self-review was done
